### PR TITLE
Improved build performance for repeated builds

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,12 +17,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.file file("${project.buildDir}/classes/java/main/ai/djl/engine/api.properties")
-    doFirst {
-        def classesDir = file("${project.buildDir}/classes/java/main/ai/djl/engine/")
-        classesDir.mkdirs()
-        def propFile = new File(classesDir, "api.properties");
-        propFile.text = "djl_version=${project.version}"
+    filesMatching("**/api.properties") {
+        expand projectVersion: project.version
     }
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.property "projectVersion", project.version
     filesMatching("**/api.properties") {
         expand projectVersion: project.version
     }

--- a/api/src/main/resources/ai/djl/engine/api.properties
+++ b/api/src/main/resources/ai/djl/engine/api.properties
@@ -1,0 +1,1 @@
+djl_version=${projectVersion}

--- a/engines/llama/build.gradle
+++ b/engines/llama/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.dir file("${project.projectDir}/build/classes/java/main/native/lib")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dirs file("${baseResourcePath}/native/lib"), file("${baseResourcePath}/nlp")
     doLast {
         def url = "https://publish.djl.ai/llama/${llamacpp_version}/jnilib/${djl_version}"
         def files = new String[]{
@@ -43,15 +44,15 @@ processResources {
         }
         copy {
             from jnilibDir
-            into "${project.projectDir}/build/classes/java/main/native/lib"
+            into "${baseResourcePath}/native/lib"
         }
 
         // write properties
-        def propFile = file("${project.projectDir}/build/classes/java/main/native/lib/llama.properties")
+        def propFile = file(baseResourcePath + "/native/lib/llama.properties")
         propFile.text = "version=${llamacpp_version}-${version}\n"
 
         url = "https://mlrepo.djl.ai/model/nlp/text_generation/ai/djl/huggingface/gguf/models.json.gz"
-        def prefix = "${project.projectDir}/build/classes/java/main/nlp/text_generation"
+        def prefix = "${baseResourcePath}/nlp/text_generation"
         def file = new File("${prefix}/ai.djl.huggingface.gguf.json")
         if (file.exists()) {
             project.logger.lifecycle("gguf index file already exists")

--- a/engines/llama/build.gradle
+++ b/engines/llama/build.gradle
@@ -13,6 +13,7 @@ compileJava.dependsOn(processResources)
 
 processResources {
     def baseResourcePath = "${project.projectDir}/build/resources/main"
+    inputs.properties('llamacpp_version': llamacpp_version, 'djl_version': djl_version)
     outputs.dirs file("${baseResourcePath}/native/lib"), file("${baseResourcePath}/nlp")
     doLast {
         def url = "https://publish.djl.ai/llama/${llamacpp_version}/jnilib/${djl_version}"

--- a/engines/ml/xgboost/build.gradle
+++ b/engines/ml/xgboost/build.gradle
@@ -40,6 +40,7 @@ compileJava.dependsOn(processResources)
 
 processResources {
     def jnilibDir = "${project.buildDir}/resources/main/lib/linux/aarch64/"
+    inputs.property "xgboost_version", xgboost_version
     outputs.dir file(jnilibDir)
     doLast {
         def url = "https://publish.djl.ai/xgboost/${xgboost_version}/jnilib/linux/aarch64/libxgboost4j.so"

--- a/engines/ml/xgboost/build.gradle
+++ b/engines/ml/xgboost/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    def jnilibDir = "${project.buildDir}/classes/java/main/lib/linux/aarch64/"
+    def jnilibDir = "${project.buildDir}/resources/main/lib/linux/aarch64/"
     outputs.dir file(jnilibDir)
     doLast {
         def url = "https://publish.djl.ai/xgboost/${xgboost_version}/jnilib/linux/aarch64/libxgboost4j.so"

--- a/engines/mxnet/jnarator/build.gradle
+++ b/engines/mxnet/jnarator/build.gradle
@@ -22,7 +22,9 @@ compileJava {
     options.compilerArgs << "--release" << "11" << "-proc:none" << "-Xlint:all,-options,-static"
 }
 
+
 jar {
+    dependsOn generateGrammarSource
     manifest {
         attributes (
             "Main-Class" : "ai.djl.mxnet.jnarator.Main",
@@ -34,4 +36,6 @@ jar {
     from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 }
 
-generateGrammarSource.finalizedBy verifyJava
+verifyJava.dependsOn generateGrammarSource
+verifyJava.dependsOn generateTestGrammarSource
+

--- a/engines/mxnet/jnarator/build.gradle
+++ b/engines/mxnet/jnarator/build.gradle
@@ -33,3 +33,5 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
     from configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 }
+
+generateGrammarSource.finalizedBy verifyJava

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -33,7 +33,13 @@ pmdMain.source = 'src/main/java'
 tasks.register('jnarator') {
     dependsOn ":engines:mxnet:jnarator:jar"
     finalizedBy verifyJava
+    inputs.file("${project.projectDir}/src/main/jna/mapping.properties")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir "${project.buildDir}/generated-src"
+
+    //always cacheable if inputs are the same
+    outputs.cacheIf { true }
+
     doLast {
         File jnaGenerator = project(":engines:mxnet:jnarator").jar.outputs.files.singleFile
         javaexec {

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -35,6 +35,8 @@ tasks.register('jnarator') {
         .withPathSensitivity(PathSensitivity.RELATIVE)
         .withPropertyName("jna/mapping.properties file")
     outputs.dir "${project.buildDir}/generated-src"
+    //there is no reason not to cache the task if Gradle needs to, so enable it
+    outputs.cacheIf { true }
 
     doLast {
         File jnaGenerator = project(":engines:mxnet:jnarator").jar.outputs.files.singleFile

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -33,12 +33,10 @@ pmdMain.source = 'src/main/java'
 tasks.register('jnarator') {
     dependsOn ":engines:mxnet:jnarator:jar"
     finalizedBy verifyJava
+    //declare inputs and outputs to allow Gradle to cache the task or skip it if inputs do not change
     inputs.file("${project.projectDir}/src/main/jna/mapping.properties")
         .withPathSensitivity(PathSensitivity.RELATIVE)
     outputs.dir "${project.buildDir}/generated-src"
-
-    //always cacheable if inputs are the same
-    outputs.cacheIf { true }
 
     doLast {
         File jnaGenerator = project(":engines:mxnet:jnarator").jar.outputs.files.singleFile

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -35,7 +35,6 @@ tasks.register('jnarator') {
         .withPathSensitivity(PathSensitivity.RELATIVE)
         .withPropertyName("jna/mapping.properties file")
     outputs.dir "${project.buildDir}/generated-src"
-    //there is no reason not to cache the task if Gradle needs to, so enable it
     outputs.cacheIf { true }
 
     doLast {

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -32,6 +32,7 @@ pmdMain.source = 'src/main/java'
 
 tasks.register('jnarator') {
     dependsOn ":engines:mxnet:jnarator:jar"
+    finalizedBy verifyJava
     outputs.dir "${project.buildDir}/generated-src"
     doLast {
         File jnaGenerator = project(":engines:mxnet:jnarator").jar.outputs.files.singleFile

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -30,7 +30,6 @@ pmdMain.source = 'src/main/java'
 
 tasks.register('jnarator') {
     dependsOn ":engines:mxnet:jnarator:jar"
-    finalizedBy verifyJava
     //declare inputs and outputs to allow Gradle to cache the task or skip it if inputs do not change
     inputs.file("${project.projectDir}/src/main/jna/mapping.properties")
         .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -58,6 +57,8 @@ tasks.register('jnarator') {
         }
     }
 }
+
+verifyJava.dependsOn jnarator
 
 test {
     environment "PATH", "src/test/bin:${environment.PATH}"

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -19,11 +19,8 @@ sourceSets {
 }
 
 processResources {
-    doFirst {
-        def classesDir = file("${project.buildDir}/classes/java/main/")
-        classesDir.mkdirs()
-        def file = new File(classesDir, "mxnet-engine.properties")
-        file.text = "djl_version=${djl_version}\nmxnet_version=${mxnet_version}"
+    filesMatching("**/mxnet-engine.properties") {
+        expand projectVersion: djl_version, mxnetVersion: mxnet_version
     }
 }
 

--- a/engines/mxnet/mxnet-engine/build.gradle
+++ b/engines/mxnet/mxnet-engine/build.gradle
@@ -19,8 +19,9 @@ sourceSets {
 }
 
 processResources {
+    inputs.properties("djlVersion": djl_version, "mxnetVersion": mxnet_version)
     filesMatching("**/mxnet-engine.properties") {
-        expand projectVersion: djl_version, mxnetVersion: mxnet_version
+        expand djlVersion: djl_version, mxnetVersion: mxnet_version
     }
 }
 
@@ -33,6 +34,7 @@ tasks.register('jnarator') {
     //declare inputs and outputs to allow Gradle to cache the task or skip it if inputs do not change
     inputs.file("${project.projectDir}/src/main/jna/mapping.properties")
         .withPathSensitivity(PathSensitivity.RELATIVE)
+        .withPropertyName("jna/mapping.properties file")
     outputs.dir "${project.buildDir}/generated-src"
 
     doLast {

--- a/engines/mxnet/mxnet-engine/src/main/resources/mxnet-engine.properties
+++ b/engines/mxnet/mxnet-engine/src/main/resources/mxnet-engine.properties
@@ -1,2 +1,2 @@
-djl_version=${projectVersion}
+djl_version=${djlVersion}
 mxnet_version=${mxnetVersion}

--- a/engines/mxnet/mxnet-engine/src/main/resources/mxnet-engine.properties
+++ b/engines/mxnet/mxnet-engine/src/main/resources/mxnet-engine.properties
@@ -1,0 +1,2 @@
+djl_version=${projectVersion}
+mxnet_version=${mxnetVersion}

--- a/engines/onnxruntime/onnxruntime-engine/build.gradle
+++ b/engines/onnxruntime/onnxruntime-engine/build.gradle
@@ -14,7 +14,8 @@ dependencies {
 }
 
 processResources {
-    outputs.dir file("${projectDir}/build/classes/java/main/nlp")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dir file("${baseResourcePath}/nlp")
     doLast {
         def url = "https://mlrepo.djl.ai/model/nlp"
         def tasks = [
@@ -24,7 +25,7 @@ processResources {
                 "text_embedding",
                 "token_classification",
         ]
-        def prefix = "${projectDir}/build/classes/java/main/nlp"
+        def prefix = "${baseResourcePath}/nlp"
         for (String task : tasks) {
             def file = new File("${prefix}/${task}/ai.djl.huggingface.onnxruntime.json")
             if (file.exists()) {

--- a/engines/onnxruntime/onnxruntime-engine/build.gradle
+++ b/engines/onnxruntime/onnxruntime-engine/build.gradle
@@ -14,8 +14,8 @@ dependencies {
 }
 
 processResources {
-    def baseResourcePath = "${project.projectDir}/build/resources/main"
-    outputs.dir file("${baseResourcePath}/nlp")
+    def basePath = "${project.projectDir}/build/resources/main/nlp"
+    outputs.dir file(basePath)
     doLast {
         def url = "https://mlrepo.djl.ai/model/nlp"
         def tasks = [
@@ -25,9 +25,9 @@ processResources {
                 "text_embedding",
                 "token_classification",
         ]
-        def prefix = "${baseResourcePath}/nlp"
+
         for (String task : tasks) {
-            def file = new File("${prefix}/${task}/ai.djl.huggingface.onnxruntime.json")
+            def file = new File("${basePath}/${task}/ai.djl.huggingface.onnxruntime.json")
             if (file.exists()) {
                 project.logger.lifecycle("model zoo metadata alrady exists: ${task}")
             } else {

--- a/engines/pytorch/pytorch-engine/build.gradle
+++ b/engines/pytorch/pytorch-engine/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "pytorchVersion": pytorch_version
     filesMatching("**/pytorch-engine.properties") {
         expand projectVersion: djl_version, pytorchVersion: pytorch_version
     }

--- a/engines/pytorch/pytorch-engine/build.gradle
+++ b/engines/pytorch/pytorch-engine/build.gradle
@@ -14,12 +14,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.file file("${project.buildDir}/classes/java/main/pytorch-engine.properties")
-    doFirst {
-        def classesDir = file("${project.buildDir}/classes/java/main/")
-        classesDir.mkdirs()
-        def propFile = new File(classesDir, "pytorch-engine.properties");
-        propFile.text = "djl_version=${djl_version}\npytorch_version=${pytorch_version}"
+    filesMatching("**/pytorch-engine.properties") {
+        expand projectVersion: djl_version, pytorchVersion: pytorch_version
     }
 }
 

--- a/engines/pytorch/pytorch-engine/src/main/resources/pytorch-engine.properties
+++ b/engines/pytorch/pytorch-engine/src/main/resources/pytorch-engine.properties
@@ -1,0 +1,2 @@
+djl_version=${projectVersion}
+pytorch_version=${pytorchVersion}

--- a/engines/tensorflow/tensorflow-engine/build.gradle
+++ b/engines/tensorflow/tensorflow-engine/build.gradle
@@ -9,11 +9,8 @@ dependencies {
 }
 
 processResources {
-    doFirst {
-        def classesDir = file("${project.buildDir}/classes/java/main/")
-        classesDir.mkdirs()
-        def file = new File(classesDir, "tensorflow-engine.properties")
-        file.text = "djl_version=${djl_version}\ntensorflow_version=${tensorflow_version}"
+    filesMatching("**/tensorflow-engine.properties") {
+        expand projectVersion: djl_version, tensorflowVersion: tensorflow_version
     }
 }
 

--- a/engines/tensorflow/tensorflow-engine/build.gradle
+++ b/engines/tensorflow/tensorflow-engine/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 }
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "tensorflowVersion": tensorflow_version
     filesMatching("**/tensorflow-engine.properties") {
         expand projectVersion: djl_version, tensorflowVersion: tensorflow_version
     }

--- a/engines/tensorflow/tensorflow-engine/src/main/resources/tensorflow-engine.properties
+++ b/engines/tensorflow/tensorflow-engine/src/main/resources/tensorflow-engine.properties
@@ -1,0 +1,2 @@
+djl_version=${projectVersion}
+tensorflow_version=${tensorflowVersion}

--- a/engines/tensorrt/build.gradle
+++ b/engines/tensorrt/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "trtVersion": trt_version, "version": version
     def baseResourcePath = "${project.projectDir}/build/resources/main"
     outputs.dir file("${baseResourcePath}/native/lib")
 

--- a/engines/tensorrt/build.gradle
+++ b/engines/tensorrt/build.gradle
@@ -14,7 +14,9 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dir file("${baseResourcePath}/native/lib")
+
     doLast {
         def url = "https://publish.djl.ai/tensorrt/${trt_version}/jnilib/${djl_version}"
         def files = [
@@ -31,14 +33,14 @@ processResources {
                 new URL("${url}/${entry.key}").withInputStream { i -> file.withOutputStream { it << i } }
             }
         }
-        file("${project.buildDir}/classes/java/main/native/lib").mkdirs()
+        file("${baseResourcePath}/native/lib").mkdirs()
         copy {
             from jnilibDir
-            into "${project.buildDir}/classes/java/main/native/lib"
+            into "${baseResourcePath}/native/lib"
         }
 
         // write properties
-        def propFile = file("${project.buildDir}/classes/java/main/native/lib/tensorrt.properties")
+        def propFile = file("${baseResourcePath}/native/lib/tensorrt.properties")
         propFile.text = "version=${trt_version}-${version}"
     }
 }

--- a/extensions/fasttext/build.gradle
+++ b/extensions/fasttext/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dir file("${baseResourcePath}/native/lib")
     doLast {
         def url = "https://publish.djl.ai/fasttext-${fasttext_version}/jnilib/${djl_version}"
         def files = [
@@ -33,11 +34,11 @@ processResources {
         }
         copy {
             from jnilibDir
-            into "${project.buildDir}/classes/java/main/native/lib"
+            into "${baseResourcePath}/native/lib"
         }
 
         // write properties
-        def propFile = file("${project.buildDir}/classes/java/main/native/lib/fasttext.properties")
+        def propFile = file("${baseResourcePath}/native/lib/fasttext.properties")
         propFile.text = "version=${fasttext_version}-${version}\n"
     }
 }

--- a/extensions/fasttext/build.gradle
+++ b/extensions/fasttext/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "fasttextVersion": fasttext_version, "version": version
     def baseResourcePath = "${project.projectDir}/build/resources/main"
     outputs.dir file("${baseResourcePath}/native/lib")
     doLast {

--- a/extensions/sentencepiece/build.gradle
+++ b/extensions/sentencepiece/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "sentencepieceVersion": sentencepiece_version, "version": version
     def baseResourcePath = "${project.projectDir}/build/resources/main"
     outputs.dir file("${baseResourcePath}/native/lib")
     doLast {

--- a/extensions/sentencepiece/build.gradle
+++ b/extensions/sentencepiece/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dir file("${baseResourcePath}/native/lib")
     doLast {
         def url = "https://publish.djl.ai/sentencepiece-${sentencepiece_version}/jnilib/${djl_version}"
         def files = [
@@ -34,11 +35,11 @@ processResources {
         }
         copy {
             from jnilibDir
-            into "${project.buildDir}/classes/java/main/native/lib"
+            into "${baseResourcePath}/native/lib"
         }
 
         // write properties
-        def propFile = file("${project.buildDir}/classes/java/main/native/lib/sentencepiece.properties")
+        def propFile = file("${baseResourcePath}/native/lib/sentencepiece.properties")
         propFile.text = "version=${sentencepiece_version}-${version}\n"
     }
 }

--- a/extensions/tokenizers/build.gradle
+++ b/extensions/tokenizers/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
+    inputs.properties "projectVersion": djl_version, "tokenizersVersion": tokenizers_version, "version": version
     def baseResourcePath = "${project.projectDir}/build/resources/main"
     outputs.dirs file("${baseResourcePath}/native/lib"), file("${baseResourcePath}/nlp")
     doLast {

--- a/extensions/tokenizers/build.gradle
+++ b/extensions/tokenizers/build.gradle
@@ -13,7 +13,8 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 processResources {
-    outputs.dir file("${project.buildDir}/classes/java/main/native/lib")
+    def baseResourcePath = "${project.projectDir}/build/resources/main"
+    outputs.dirs file("${baseResourcePath}/native/lib"), file("${baseResourcePath}/nlp")
     doLast {
         def url = "https://publish.djl.ai/tokenizers"
         def files = [
@@ -40,11 +41,11 @@ processResources {
         }
         copy {
             from jnilibDir
-            into "${project.buildDir}/classes/java/main/native/lib"
+            into "${baseResourcePath}/native/lib"
         }
 
         // write properties
-        def propFile = file("${project.buildDir}/classes/java/main/native/lib/tokenizers.properties")
+        def propFile = file("${baseResourcePath}/native/lib/tokenizers.properties")
         propFile.text = "version=${tokenizers_version}-${version}\n"
 
         url = "https://mlrepo.djl.ai/model/nlp"
@@ -55,7 +56,7 @@ processResources {
                 "text_embedding",
                 "token_classification",
         ]
-        def prefix = "${project.buildDir}/classes/java/main/nlp"
+        def prefix = "${baseResourcePath}/nlp"
         for (String task : tasks) {
             def file = new File("${prefix}/${task}/ai.djl.huggingface.pytorch.json")
             if (file.exists()) {

--- a/tools/conf/checkstyle.xml
+++ b/tools/conf/checkstyle.xml
@@ -15,13 +15,13 @@
     -->
 
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyle.suppressions.file}"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
     <module name="SuppressWarningsFilter"/>
 
     <!-- Headers -->
     <module name="Header">
-        <property name="headerFile" value="${checkstyle.licenseHeader.file}"/>
+        <property name="headerFile" value="${config_loc}/licenseHeader.java"/>
         <property name="fileExtensions" value="java"/>
         <property name="ignoreLines" value="2"/>
         <property name="id" value="header"/>

--- a/tools/gradle/check.gradle
+++ b/tools/gradle/check.gradle
@@ -38,11 +38,8 @@ checkstyle {
     toolVersion = "10.14.2"
     ignoreFailures = false
     checkstyleTest.enabled = true
-    configProperties = [
-            "checkstyle.suppressions.file" : file("${rootProject.projectDir}/tools/conf/suppressions.xml"),
-            "checkstyle.licenseHeader.file": file("${rootProject.projectDir}/tools/conf/licenseHeader.java")
-    ]
-    configFile = file("${rootProject.projectDir}/tools/conf/checkstyle.xml")
+    //use relative paths to ensure build caching works across different locations
+    configDirectory = file(relativePath(file("${rootProject.projectDir}/tools/conf")))
 }
 checkstyleMain {
     classpath += configurations.compileClasspath

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -39,6 +39,10 @@ class JavaFormatterPlugin implements Plugin<Project> {
         }
 
         project.task('verifyJava') {
+            def resultFilePath = "build/verifyJava-result.txt"
+            inputs.files(project.sourceSets*.allSource)
+            inputs.files(project.fileTree('generated-src'))
+            outputs.file(project.file(resultFilePath))
             doLast {
                 Main formatter = new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in)
                 for (item in project.sourceSets) {
@@ -55,6 +59,7 @@ class JavaFormatterPlugin implements Plugin<Project> {
                         }
                     }
                 }
+                project.file(resultFilePath).write('Success')
             }
         }
     }

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -41,7 +41,11 @@ class JavaFormatterPlugin implements Plugin<Project> {
         project.task('verifyJava') {
             def resultFilePath = "build/verifyJava-result.txt"
             inputs.files(project.sourceSets*.allSource)
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+                    .withPropertyName('sourceFiles')
             inputs.files(project.fileTree('generated-src'))
+                    .withPropertyName('generatedSourceFiles')
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
             outputs.file(project.file(resultFilePath))
             //is always cacheable if inputs are the same
             outputs.cacheIf { true }

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -43,6 +43,8 @@ class JavaFormatterPlugin implements Plugin<Project> {
             inputs.files(project.sourceSets*.allSource)
             inputs.files(project.fileTree('generated-src'))
             outputs.file(project.file(resultFilePath))
+            //is always cacheable if inputs are the same
+            outputs.cacheIf { true }
             doLast {
                 Main formatter = new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in)
                 for (item in project.sourceSets) {

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -48,7 +48,6 @@ class JavaFormatterPlugin implements Plugin<Project> {
                     .withPropertyName('generatedSourceFiles')
                     .withPathSensitivity(PathSensitivity.RELATIVE)
             outputs.file(project.file(resultFilePath))
-            //there is no reason not to cache the task if Gradle needs to, so enable it
             outputs.cacheIf { true }
 
             doLast {

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -48,6 +48,8 @@ class JavaFormatterPlugin implements Plugin<Project> {
                     .withPropertyName('generatedSourceFiles')
                     .withPathSensitivity(PathSensitivity.RELATIVE)
             outputs.file(project.file(resultFilePath))
+            //there is no reason not to cache the task if Gradle needs to, so enable it
+            outputs.cacheIf { true }
 
             doLast {
                 Main formatter = new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in)

--- a/tools/gradle/java-formatter.gradle
+++ b/tools/gradle/java-formatter.gradle
@@ -39,6 +39,7 @@ class JavaFormatterPlugin implements Plugin<Project> {
         }
 
         project.task('verifyJava') {
+            //declare normalized inputs and outputs to allow Gradle to cache the task or skip it if inputs do not change
             def resultFilePath = "build/verifyJava-result.txt"
             inputs.files(project.sourceSets*.allSource)
                     .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -47,8 +48,7 @@ class JavaFormatterPlugin implements Plugin<Project> {
                     .withPropertyName('generatedSourceFiles')
                     .withPathSensitivity(PathSensitivity.RELATIVE)
             outputs.file(project.file(resultFilePath))
-            //is always cacheable if inputs are the same
-            outputs.cacheIf { true }
+
             doLast {
                 Main formatter = new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in)
                 for (item in project.sourceSets) {


### PR DESCRIPTION
## Description ##

Some Gradle tasks were configured to prevent Gradle from using up-to-date checks (and build caching, if enabled). This meant that some tasks were being executed even if the output was not different, wasting build time.


This PR proposes changes to the build scripts to make the builds more efficient for repeated builds on the same machine. This should save a few seconds, with more improvements if build caching were to be enabled.

Some key highlights:

- tasks that share output locations (eg. tasks that downloaded files directly into build/classes) would prevent Gradle from identifying the owning tasks, which disables caching/up-to-date checks. These were split into separate locations and left to the `processResources`/`jar` tasks to collect. For some modules, the file was placed directly into the source, and the version property was injected to ensure repeatability in the build  - feedback is welcome on this change.

- tasks that do not declare inputs/outputs or have no outputs also disable the checks. These tasks were updated to include the right inputs/outputs. In the case of the `verifyJava` task, a new output file was created to let Gradle know when the task was completed successfully previously. If inputs do not change, Gradle will automatically skip these tasks, as the output would have remained the same.

- absolute paths were changed to relative paths (or normalized to only consider relative paths). If remote build caches are enabled, the build cache will be used for these tasks across any connected build machine.


The improvements were discovered through analyzing the build with [Develocity](https://gradle.com/develocity/). This [Build Scan](https://scans.gradle.com/s/w2yxmjzm2ciqm) is of a second `build` run after the improvements were implemented. 

The [timeline view](https://scans.gradle.com/s/w2yxmjzm2ciqm/timeline) shows a breakdown of where time was spent in the build.  In this case, as it was performed on a machine that had already run the `build` task, you can see [here](https://scans.gradle.com/s/w2yxmjzm2ciqm/timeline?outcome=success,failed) that no tasks were executed as they were all up to date.

